### PR TITLE
bot

### DIFF
--- a/.github/workflows/update_formula.yml
+++ b/.github/workflows/update_formula.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        token: ${{secrets.CGCIBOT_PAT}}
     - name: Generate Formula
       working-directory: ./Versions
       run: |
@@ -21,5 +23,5 @@ jobs:
     - name: Commit changes
       uses: EndBug/add-and-commit@v9
       with:
-        default_author: github_actions
+        author_name: cg-ci-bot
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Welcome!
+
+We're so glad you're thinking about contributing to a [open source project of the U.S. government](https://code.gov/)! If you're unsure about anything, just ask -- or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
+
+We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md).
+
+## Policies
+
+We want to ensure a welcoming environment for all of our projects. Our staff follow the [TTS Code of Conduct](https://18f.gsa.gov/code-of-conduct/) and all contributors should do the same.
+
+We adhere to the [18F Open Source Policy](https://github.com/18f/open-source-policy). If you have any questions, just [shoot us an email](mailto:18f@gsa.gov).
+
+As part of a U.S. government agency, the General Services Administration (GSA)’s Technology Transformation Services (TTS) takes seriously our responsibility to protect the public’s information, including financial and personal information, from unwarranted disclosure. For more information about security and vulnerability disclosure for our projects, please read our [18F Vulnerability Disclosure Policy](https://18f.gsa.gov/vulnerability-disclosure-policy/).
+
+## Public domain
+
+This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+All contributions to this project will be released under the CC0 dedication. By submitting a pull request or issue, you are agreeing to comply with this waiver of copyright interest.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# License
+
+As a work of the [United States government](https://www.usa.gov/), this project is in the public domain within the United States of America.
+
+Additionally, we waive copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication.
+
+## CC0 1.0 Universal Summary
+
+This is a human-readable summary of the [Legal Code (read the full text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+### No Copyright
+
+The person who associated a work with this deed has dedicated the work to the public domain by waiving all of their rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.
+
+You can copy, modify, distribute, and perform the work, even for commercial purposes, all without asking permission.
+
+### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This is repo holds the homebrew formulae for utilities from [cloud.gov](https://
 ## Installation
 
 ```sh
-brew install rbogle/cloudgov/<formula>
+brew install cloud-gov/cloudgov/<formula>
 ```
 
 or
 
 ```sh
-brew tap rbogle/cloudgov
+brew tap cloud-gov/cloudgov
 brew install <formula>
 ```
 
@@ -22,4 +22,5 @@ brew install <formula>
 ## Development
 
 New formula should be added to the formula directory.
-A workflow is enabled for automatic updating of forumla based on changes to *.env files in the Versions directory. This simply leverages bash environment variables and the shell `envsubst` command to generate new formula `.rb` files in Formula based on changes to any `.env` files in Versions.
+
+A workflow is enabled for automatic updating of forumla based on changes to `formula`/`formula`.env files in the Versions directory. This simply leverages bash environment variables and the shell `envsubst` command to generate new formula `.rb` files in Formula directory based on changes to any `formula.env` files in directories under ./Versions.


### PR DESCRIPTION
## Changes proposed in this pull request:
-  use cg-ci-bot account to generate a new formula file via workflow
-  this is triggered by a push from the release workflow in cloud-gov/cg-manage-rds by cg-ci-bot
-  this way the homebrew formula is always in-sync with any new release in cg-manage-rds

## Security considerations
None. 
