### PR TITLE
update template formula for cg-manage-rds to include semver dependency

### DIFF
--- a/Versions/cg-manage-rds/cg-manage-rds.tmpl
+++ b/Versions/cg-manage-rds/cg-manage-rds.tmpl
@@ -14,6 +14,11 @@ class CgManageRds < Formula
         url "https://files.pythonhosted.org/packages/42/e1/4cb2d3a2416bcd871ac93f12b5616f7755a6800bccae05e5a99d3673eb69/click-8.1.2.tar.gz"
         sha256 "479707fe14d9ec9a0757618b7a100a0ae4c4e236fac5b7f80ca68028141a1a72"
     end
+
+    resource "semver" do
+        url "https://files.pythonhosted.org/packages/41/6c/a536cc008f38fd83b3c1b98ce19ead13b746b5588c9a0cb9dd9f6ea434bc/semver-3.0.2.tar.gz"
+        sha256 "6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc"
+    end
  
     def install
       virtualenv_install_with_resources


### PR DESCRIPTION
Fixes https://github.com/cloud-gov/cg-manage-rds/issues/22

## Changes proposed in this pull request:

Update template formula for cg-manage-rds to include semver dependency which is now required by the package. Without this change, the homebrew package currently fails with:

```
ModuleNotFoundError: No module named 'semver'
```

In the future, we should investigate auto-populating the dependencies using something mentioned here: https://docs.brew.sh/Python-for-Formula-Authors

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just adding required dependency for formula
